### PR TITLE
Potential fix for code scanning alert no. 1030: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: Generate and Deploy DocC
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/artemisia-absynthium/arachne/security/code-scanning/1030](https://github.com/artemisia-absynthium/arachne/security/code-scanning/1030)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow pushes to a branch, it needs `contents: write`. No other permissions are required for the steps shown. The best way to fix this is to add the following block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs in the workflow:

```yaml
permissions:
  contents: write
```

This change should be made at the top of `.github/workflows/docc.yml`, after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
