### PR TITLE
Potential fix for code scanning alert no. 1029: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/artemisia-absynthium/arachne/security/code-scanning/1029](https://github.com/artemisia-absynthium/arachne/security/code-scanning/1029)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/swift.yml`. The block should be placed at the top level (before `jobs:`) to apply to all jobs in the workflow, unless a job-specific override is needed. For this workflow, the minimal required permission is `contents: read`, as the workflow only checks out code, builds, tests, and uploads coverage, none of which require write access to repository contents. If in the future a step requires additional permissions (e.g., creating issues or pull requests), those can be added as needed. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
